### PR TITLE
Decode GIFs as static images on Android

### DIFF
--- a/android/src/main/java/com/reactnativeimagemanipulator/RNImageManipulatorModule.java
+++ b/android/src/main/java/com/reactnativeimagemanipulator/RNImageManipulatorModule.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -53,6 +54,10 @@ public class RNImageManipulatorModule extends ReactContextBaseJavaModule {
         ImageRequestBuilder
             .newBuilderWithSource(Uri.parse(uriString))
             .setRotationOptions(RotationOptions.autoRotate())
+            .setImageDecodeOptions(
+                    ImageDecodeOptions.newBuilder()
+                            .setForceStaticImage(true)
+                            .build())
             .build();
     final DataSource<CloseableReference<CloseableImage>> dataSource
         = Fresco.getImagePipeline().fetchDecodedImage(imageRequest, getReactApplicationContext());


### PR DESCRIPTION
### Problem

https://github.com/Expensify/App/issues/14751

Platform: Android
GIFs are not being decoded as static images, and therefore are resulting in a decoding error when uploading avatars.

[Screencast from 2023-02-13 04:28:30 AM.webm](https://user-images.githubusercontent.com/1311325/218460333-9d5d2605-cd54-4026-8ddc-e154ecd251f4.webm)

### Solution

Use the `ForceStaticImage` option from the Fresco decoder to decode the first frame only in a GIF image.

### Result

[Screencast from 2023-02-13 04:34:10 AM.webm](https://user-images.githubusercontent.com/1311325/218460677-909c9f29-d385-4b7d-9c09-ce8a77e2f153.webm)



